### PR TITLE
remove all Arc<dyn WindowSurface>

### DIFF
--- a/src/graphics/frame_context.rs
+++ b/src/graphics/frame_context.rs
@@ -1,5 +1,5 @@
 use crate::graphics::{
-    vulkan::{Device, Swapchain},
+    vulkan::{Device, Swapchain, WindowSurface},
     Draw2d, Frame,
 };
 
@@ -118,12 +118,15 @@ impl FrameContext {
     /// rebuild the swapchain.
     ///
     /// Returns a clone of the swapchain which can be used by other systems.
-    pub fn rebuild_swapchain(&mut self) -> Result<Arc<Swapchain>> {
+    pub fn rebuild_swapchain(
+        &mut self,
+        window_surface: &dyn WindowSurface,
+    ) -> Result<Arc<Swapchain>> {
         unsafe {
             self.device.logical_device.device_wait_idle()?;
             self.frames_in_flight.clear();
         }
-        self.swapchain = self.swapchain.rebuild()?;
+        self.swapchain = self.swapchain.rebuild(window_surface)?;
         self.frames_in_flight =
             Frame::create_n_frames(&self.device, &self.swapchain.framebuffers)?;
         self.swapchain_state = SwapchainState::Ok;

--- a/src/graphics/mod.rs
+++ b/src/graphics/mod.rs
@@ -12,8 +12,6 @@ pub use self::{
 
 use self::vulkan::{Device, Swapchain, WindowSurface};
 
-use std::sync::Arc;
-
 use anyhow::Result;
 
 /// The application's graphics subsystem.
@@ -27,10 +25,9 @@ pub struct Graphics {
 
 impl Graphics {
     /// Instantiate the graphics subsystem.
-    pub fn new(window_surface: Arc<dyn WindowSurface>) -> Result<Self> {
-        let device = Device::new(window_surface.clone())?;
-        let swapchain =
-            Swapchain::new(device.clone(), window_surface.clone(), None)?;
+    pub fn new(window_surface: &dyn WindowSurface) -> Result<Self> {
+        let device = Device::new(window_surface)?;
+        let swapchain = Swapchain::new(device.clone(), window_surface, None)?;
 
         let frame_context =
             FrameContext::new(device.clone(), swapchain.clone())?;
@@ -43,18 +40,21 @@ impl Graphics {
     }
 
     /// Render a single frame to the screen.
-    pub fn render(&mut self) -> Result<()> {
+    pub fn render(&mut self, window_surface: &dyn WindowSurface) -> Result<()> {
         let swapchain_state = self.frame_context.draw_frame(&self.draw2d)?;
         if swapchain_state == SwapchainState::NeedsRebuild {
-            self.rebuild_swapchain()?;
+            self.rebuild_swapchain(window_surface)?;
         }
         Ok(())
     }
 
     /// Replace the swapchain and all dependent resources in the Triangle
     /// subsystem.
-    pub fn rebuild_swapchain(&mut self) -> Result<()> {
-        let swapchain = self.frame_context.rebuild_swapchain()?;
+    pub fn rebuild_swapchain(
+        &mut self,
+        window_surface: &dyn WindowSurface,
+    ) -> Result<()> {
+        let swapchain = self.frame_context.rebuild_swapchain(window_surface)?;
         self.draw2d.replace_swapchain(swapchain)?;
         Ok(())
     }

--- a/src/graphics/vulkan/device/mod.rs
+++ b/src/graphics/vulkan/device/mod.rs
@@ -28,9 +28,6 @@ pub struct Device {
     pub graphics_queue: Arc<Queue>,
     pub present_queue: Arc<Queue>,
 
-    /// A reference to the window surface used to create this device
-    pub window_surface: Arc<dyn WindowSurface>,
-
     /// The Vulkan library instance used to create this device
     pub instance: Arc<Instance>,
 }
@@ -38,14 +35,13 @@ pub struct Device {
 impl Device {
     /// Create a new device based on this application's required features and
     /// properties.
-    pub fn new(window_surface: Arc<dyn WindowSurface>) -> Result<Arc<Device>> {
+    pub fn new(window_surface: &dyn WindowSurface) -> Result<Arc<Device>> {
         let instance = window_surface.clone_vulkan_instance();
-        let physical_device =
-            pick_physical_device(&instance, window_surface.as_ref())?;
+        let physical_device = pick_physical_device(&instance, window_surface)?;
         let queue_family_indices = QueueFamilyIndices::find(
             &physical_device,
             &instance.ash,
-            window_surface.as_ref(),
+            window_surface,
         )?;
         let logical_device = create_logical_device(
             &instance,
@@ -60,7 +56,6 @@ impl Device {
             logical_device,
             graphics_queue,
             present_queue,
-            window_surface,
             instance,
         });
 

--- a/src/graphics/vulkan/swapchain/mod.rs
+++ b/src/graphics/vulkan/swapchain/mod.rs
@@ -27,8 +27,6 @@ pub struct Swapchain {
     pub format: vk::Format,
     pub color_space: vk::ColorSpaceKHR,
 
-    pub window_surface: Arc<dyn WindowSurface>,
-
     device: Arc<Device>,
 }
 
@@ -37,23 +35,23 @@ impl Swapchain {
     /// current size of the framebuffer.
     pub fn new(
         device: Arc<Device>,
-        window_surface: Arc<dyn WindowSurface>,
+        window_surface: &dyn WindowSurface,
         previous: Option<&Swapchain>,
     ) -> Result<Arc<Self>> {
         let image_format = selection::choose_surface_format(
-            window_surface.as_ref(),
+            window_surface,
             &device.physical_device,
         );
         let present_mode = selection::choose_present_mode(
-            window_surface.as_ref(),
+            window_surface,
             &device.physical_device,
         );
         let extent = selection::choose_swap_extent(
-            window_surface.as_ref(),
+            window_surface,
             &device.physical_device,
         )?;
         let image_count = selection::choose_image_count(
-            window_surface.as_ref(),
+            window_surface,
             &device.physical_device,
         )?;
 
@@ -131,18 +129,16 @@ impl Swapchain {
             extent,
             format: image_format.format,
             color_space: image_format.color_space,
-            window_surface,
             device,
         }))
     }
 
     /// Rebuild a new swapchain using this swapchain as a reference.
-    pub fn rebuild(&self) -> Result<Arc<Self>> {
-        Self::new(
-            self.device.clone(),
-            self.window_surface.clone(),
-            Some(&self),
-        )
+    pub fn rebuild(
+        &self,
+        window_surface: &dyn WindowSurface,
+    ) -> Result<Arc<Self>> {
+        Self::new(self.device.clone(), window_surface, Some(&self))
     }
 }
 


### PR DESCRIPTION
because:
- it was clumsy and forced the glfw WindowSurface impl to use
  RefCell internally
- I was getting nervous about having references to things all
  over the place

NOTE:
- The current solutions means that the order of declarations in
  the application struct is really important. If window_surface
  is listed before graphics, then the window gets destroyed
  *before* the other graphical resources :O
- The vulkan validation layers catch this and throw a fit, so
  it's a noticable mistake, as such I think this is a fair
  trade-off for making the rest of the codebase easier to reason
  about.